### PR TITLE
Webcam adjustment

### DIFF
--- a/arduino/arduino_controller/arduino_controller.ino
+++ b/arduino/arduino_controller/arduino_controller.ino
@@ -32,7 +32,7 @@ const int analog_pins[NUM_ANALOG] = {ADC0, ADC1, ADC2};
 #endif
 
 /* firmware version */
-const static int firmware_version[NUM_INPUT] = {0, 1, 0};
+const static int firmware_version[3] = {0, 1, 0};
 
 /* Define available CmdMessenger commands */
 enum {
@@ -170,6 +170,10 @@ void attach_callbacks(void) {
 void read_btns(void) {
     static uint8_t y_old[NUM_INPUT]={0,0,0};
     int state_change = 0;
+
+    for(pin=0; pin<NUM_INPUT; pin++) {
+        y_old[pin]=0;
+    }
 
     for(pin=0;pin<NUM_INPUT;pin++){
         y_old[pin] = y_old[pin] - (y_old[pin] >> 2);

--- a/arduino/arduino_controller/arduino_controller.ino
+++ b/arduino/arduino_controller/arduino_controller.ino
@@ -33,6 +33,7 @@ const int analog_pins[NUM_ANALOG] = {ADC0, ADC1, ADC2};
 
 /* firmware version */
 const static int firmware_version[3] = {0, 1, 0};
+unsigned long delays[1]={50};
 
 /* Define available CmdMessenger commands */
 enum {
@@ -66,6 +67,10 @@ enum ouptuts {
 
 enum analogs {
     read_webcam_angle
+};
+
+enum delays{
+    servo_delay
 };
 
 Servo webcam_angle;       // Servo to adjust webcam angle
@@ -168,7 +173,7 @@ void attach_callbacks(void) {
  * the debounce is handled in two stages, a simulated RC filter and a schmitt trigger.
  */
 void read_btns(void) {
-    static uint8_t y_old[NUM_INPUT]={0,0,0};
+    static uint8_t y_old[NUM_INPUT];
     int state_change = 0;
 
     for(pin=0; pin<NUM_INPUT; pin++) {
@@ -205,8 +210,11 @@ void read_btns(void) {
 void adjust_webcam_angle() {
     int val;
     val = analogRead(analog_pins[read_webcam_angle]);
+    Serial.println(val, HEX);
     val = map(val, 0, 1023, SERVO_MIN_ANGLE, SERVO_MAX_ANGLE);
     webcam_angle.write(val);
+
+    delays[servo_delay]=millis();
 }
 
 void setup() {
@@ -233,10 +241,16 @@ void setup() {
         pinMode(output_pins[pin], OUTPUT);
         digitalWrite(output_pins[pin], LOW);
     }
+
+    webcam_angle.attach(output_pins[set_webcam_angle]);
 }
 
 void loop() {
+
     c.feedinSerialData();
     read_btns();
+    if (millis() - delays[servo_delay]) {
+        adjust_webcam_angle();
+    }
 }
 

--- a/python/notes
+++ b/python/notes
@@ -1,2 +1,5 @@
 COMport permissions to run the probe script to find ports
 
+sudo picocom -b 9600 /dev/ttyUSB0
+- this will steal the serial output from the board, but that's ok for testing purposes.
+


### PR DESCRIPTION
Large rearrange of the pin assignment logic.

In order to test on the Nano I have and execute on the Leonardo, I added compiler directives to change pin assignments based on architecture.  I made the pin handling more generic by using a <NUM_PINS> variable where appropriate instead of hard coding 3 as used for testing.

Pins are now split between Input, Output, and Analog.  For each set, there are NUM_<type> and enums.  The enums allow for using pin names instead of numbers throughout the code and that's it.  The pressure switch was changed to a PIR sensor, so it's name was updated accordingly.

The major functionality change is adding logic for a Servo motor, which is quite simple using the Servo library.  A servo is declared as 'webcam_angle', and the input is currently an analog signal (e.g. potentiometer.)  The servo requires a delay to wait for movement to complete before writing again, so I added a "waits" and "timers" array, currently with one element, to centralize any delays.