### PR TITLE
Control webcam servo using PWM instead of Servo library

### DIFF
--- a/arduino/arduino_controller/README.md
+++ b/arduino/arduino_controller/README.md
@@ -1,0 +1,31 @@
+# Arduino Controller
+This software runs on the Arduino Mega 2560 in the NGALAC. It's responsible for a few things:
+1. Controlling the lights, including stage left/right (i.e. controller storage), the On-Air sign, and the NGALAC sign.
+2. Detecting when the stream button is pressed and notifying the streaming PC.
+3. Moving the player camera when the knob is turned.
+4. Detecting when the player leaves the console based on the PIR sensor.
+
+## Webcam servo control using PWM
+The Arduino uses a library called FastLED to control the LED strips. FastLED requires precise timing and so it disables interrupts when it is updating the LEDs. The Arduino Servo library uses interrupts to control servos, so FastLED interferes with the Arduino Servo library, and we can't use it. See [this article](https://github.com/FastLED/FastLED/wiki/Interrupt-problems) for more details.
+
+To work around this, we use PWM on pin 2 to control the servo. PWM is unaffected by whether interrupts are disabled. This has a side-effect of interfering with `analogWrite()` functionality on pins 3 and 5. So if you notice some issue with `analogWrite` on those pins, this is probably why.
+
+I was unable to find a library to configure the PWM pins, so I directly modified some registers on the Arduino to do what I wanted.
+
+### Low-level details
+[See this Wikipedia article for an explanation of the control signal that the servo expects.](https://en.wikipedia.org/wiki/Servo_control)
+
+We use timer3 (a 16-bit timer) in Fast PWM mode. We set it in PWM mode 14 (`WGM33:WGM30 == 0b1110`), which means the timer will count up to ICR3 and then reset to 0.
+
+We set the prescaler to `0b010`, which means `clk / 8`, which means 2 MHz (since the Arduino is 16 MHz). We set ICR3 to 40000. This means that the timer will wrap around every `1 sec / 2e6 * 4e4 == 20 msec`, or 50 Hz, which is the period that a servo expects.
+
+We set OCR3B to some value between 2000 and 4000, depending on the position that we want to set the servo. This means that the pulse will vary from 1ms to 2ms, which is what the servo expects.
+
+### Using a different pin
+If, for some reason, you want to put the servo on some pin other than 2, here are some pointers:
+
+* Only pins 2, 3, 5, 6, 7, 8, 11, and 12 will work. Pins 4, 9, 10, and 13 are controlled by 8-bit timers, which are too coarse-grained (the servo will only be able to move to 10 or so positions). Pins 8, 11, and 12 aren't wired up on the shield currently, so those are also probably not good. The rest of the pins won't work because they're not PWM.
+* Once you've picked which pin you want, you will need to figure out which timer and output compare register it corresponds to. [This post](https://forum.arduino.cc/index.php?topic=72092.0) discusses the pin -> timer mapping. [This page](http://astro.neutral.org/arduino/arduino-pwm-pins-frequency.shtml) gives the pin -> output compare register mapping.
+* Update the source code and replace references to TCCR3A, TCCR3B, ICR3, and OCR3B to the appropriate registers.
+* If you want to add another servo for some reason, I'd recommend putting it on pins 3 or 5, because TCCR3A, TCCR3B, and ICR3 are already set up for you—you just need to set OCR3A (pin 5) or OCR3C (pin 3) appropriately.
+

--- a/arduino/arduino_controller/arduino_controller.ino
+++ b/arduino/arduino_controller/arduino_controller.ino
@@ -1,6 +1,6 @@
 #include "CmdMessenger.h"
-#include "Servo.h"
 #include <FastLED.h>
+#include <avr/io.h>
 
 #define FASTLED_ALLOW_INTERRUPTS 0
 #define ONAIR_NUM 198
@@ -24,8 +24,7 @@ CRGB case_leds[CASE_NUM];
 volatile static int stage;
 
 #define SERVO_MAX_ANGLE 110
-#define SERVO_MIN_ANGLE 75
-Servo webcam_angle;       // Servo to adjust webcam angle
+#define SERVO_MIN_ANGLE 10
 
 #define NUM_INPUT 3
 enum inputs {
@@ -38,7 +37,7 @@ const int input_pins[NUM_INPUT] = {32, 34, 11};
 #define NUM_OUTPUT 3
 enum ouptuts {
     blank2,
-    set_webcam_angle,
+    webcam_servo,
     blank3
 };
 const int output_pins[NUM_OUTPUT] = {53, 5, 51};
@@ -49,20 +48,20 @@ enum analogs {
     read_pir,
     stream_button_light,  // output to control the stream button light
 };
-const int analog_pins[NUM_ANALOG] = {A0, A1, 7};
+const int analog_pins[NUM_ANALOG] = {A1, A1, 7};
 
 /*
-#if defined(__AVR_ATmega328P__)
-const int input_pins[NUM_INPUT] = {5, 6, 7};
-const int output_pins[NUM_OUTPUT] = {2, 3, 4};
-const int analog_pins[NUM_ANALOG] = {A0, A1, A2};
-#endif
+    #if defined(__AVR_ATmega328P__)
+    const int input_pins[NUM_INPUT] = {5, 6, 7};
+    const int output_pins[NUM_OUTPUT] = {2, 3, 4};
+    const int analog_pins[NUM_ANALOG] = {A0, A1, A2};
+    #endif
 
-#if defined(__AVR_ATmega32U4__)
-const int input_pins[NUM_INPUT] = {9, 10, 11};
-const int output_pins[NUM_OUTPUT] = {5, 6, 7};
-const int analog_pins[NUM_ANALOG] = {ADC0, ADC1, ADC2};
-#endif
+    #if defined(__AVR_ATmega32U4__)
+    const int input_pins[NUM_INPUT] = {9, 10, 11};
+    const int output_pins[NUM_OUTPUT] = {5, 6, 7};
+    const int analog_pins[NUM_ANALOG] = {ADC0, ADC1, ADC2};
+    #endif
 */
 
 /* firmware version */
@@ -72,27 +71,27 @@ const static int firmware_version[3] = {0, 1, 5};
 #define STATUS_BITS 15
 int status[STATUS_BITS];
 
-/* 0 digital input 0
- * 1 digital input 1
- * 2 digital input 2
- * 
- * 3 digital output 0
- * 4 digital output 1
- * 5 digital output 2
- * 
- * 6 digital input pin latched 0
- * 7 digital input pin latched 1
- * 8 digital input pin latched 2
- * 
- *  9 digital input pin value 0
- * 10 digital input pin value 1
- * 11 digital input pin value 2
- * 
- * 12 digital input pin player 
- * 13 digital input pin stream status
- * 14 digital input pin stream toggle
- * 
- */
+/*  0 digital input 0
+    1 digital input 1
+    2 digital input 2
+
+    3 digital output 0
+    4 digital output 1
+    5 digital output 2
+
+    6 digital input pin latched 0
+    7 digital input pin latched 1
+    8 digital input pin latched 2
+
+    9 digital input pin value 0
+    10 digital input pin value 1
+    11 digital input pin value 2
+
+    12 digital input pin player
+    13 digital input pin stream status
+    14 digital input pin stream toggle
+
+*/
 
 
 /* Define available CmdMessenger commands */
@@ -113,21 +112,21 @@ enum {
 
 /* Timers - may move to hw timers but currently unecessary */
 #define NUM_DELAYS 4
-enum delays{
+enum delays {
     servo_delay,
     player_activity,
     air_status,
     stream_light
 };
-static unsigned long timers[NUM_DELAYS]={0, 0, 0, 0};
-const unsigned long waits[NUM_DELAYS]={50, 900000, 0, 0};  // 15m * 60s * 1000ms
+static unsigned long timers[NUM_DELAYS] = {0, 0, 0, 0};
+const unsigned long waits[NUM_DELAYS] = {50, 900000, 0, 0}; // 15m * 60s * 1000ms
 //const unsigned long waits[NUM_DELAYS]={50, 15000};  // 15m * 60s * 1000ms
 
 
-/* 
- * Button handling 
- * The buttons need debouncing, and values ma or may not need latchhing.  
- */
+/*
+    Button handling
+    The buttons need debouncing, and values ma or may not need latchhing.
+*/
 int pin_latch_value[NUM_INPUT];
 int pin_latched[NUM_INPUT];
 int pin_active[NUM_INPUT];
@@ -142,12 +141,12 @@ int pin = 0;            // pin interation
 
 /* Initialize CmdMessenger -- this should match PyCmdMessenger instance */
 const int BAUD_RATE = 9600;
-CmdMessenger c = CmdMessenger(Serial,',',';','/');
+CmdMessenger c = CmdMessenger(Serial, ',', ';', '/');
 
 /* Create callback functions to deal with incoming messages */
 
 /* reply to ping with a pong */
-void do_pong(void){
+void do_pong(void) {
     c.sendCmd(pong, "pong");
 }
 
@@ -160,20 +159,20 @@ void do_send_firmware(void) {
     c.sendCmdEnd();
 }
 
-/* State is defined as the currently values of:
- * {
- *   debounced pins,
- *   current pin values,
- *   pin lateched state,
- *   pin latched value
- * }
- * This lets the microcontroller do a standard send of information to the server, and the server can
- * decide which information is interesting.  
+/*  State is defined as the currently values of:
+    {
+     debounced pins,
+     current pin values,
+     pin lateched state,
+     pin latched value
+    }
+    This lets the microcontroller do a standard send of information to the server, and the server can
+    decide which information is interesting.
 */
-void send_state(void){
+void send_state(void) {
     c.sendCmdStart(ret_state);
 
-    for(pin=0; pin<STATUS_BITS; pin++) {
+    for (pin = 0; pin < STATUS_BITS; pin++) {
         c.sendCmdBinArg(status[pin]);
     }
 
@@ -181,43 +180,43 @@ void send_state(void){
 }
 
 /* sends only value of pir input */
-void is_player(void){
+void is_player(void) {
     c.sendBinCmd(player, (int)pin_state[read_pir]);
 }
 
 /* a 'pretty much a stub' for handling lights.  Once specs start rolling in, this will be fleshed out */
-void handle_lights(void){
-  
-    if(status[13]==1) {
-      // on air lights
-      if(status[14] == 1) {
-        go_on_air_lights();
-      }
-      // button light
-      stream_button_on_air();
+void handle_lights(void) {
+
+    if (status[13] == 1) {
+        // on air lights
+        if (status[14] == 1) {
+            go_on_air_lights();
+        }
+        // button light
+        stream_button_on_air();
     } else {
-      // off air lights
-      if(status[14] == 1) {
-        go_off_air_lights();
-      }
-      // button light
-      stream_button_off_air();
+        // off air lights
+        if (status[14] == 1) {
+            go_off_air_lights();
+        }
+        // button light
+        stream_button_off_air();
     }
     test_patterns();
 }
 
-void on_unknown_command(void){
-    c.sendCmd(error,"Command without callback.");
+void on_unknown_command(void) {
+    c.sendCmd(error, "Command without callback.");
 }
 
-/* When the microcontroller ack's the state, it may (probably will) return a call to unlatch the pins to capture new
- * button presses.  This will need to change as button behavior changes.  only "latchable" pins will be "unlatched."
- * or more specifically longer presses for the servo motor cannot be handled via a latched momentary press.
- */
-void unlatch_pins(){
-    for(pin=0;pin<NUM_INPUT;pin++){
-        pin_latched[pin]=0;
-        pin_latch_value[pin]=0;
+/*  When the microcontroller ack's the state, it may (probably will) return a call to unlatch the pins to capture new
+    button presses.  This will need to change as button behavior changes.  only "latchable" pins will be "unlatched."
+    or more specifically longer presses for the servo motor cannot be handled via a latched momentary press.
+*/
+void unlatch_pins() {
+    for (pin = 0; pin < NUM_INPUT; pin++) {
+        pin_latched[pin] = 0;
+        pin_latch_value[pin] = 0;
     }
 }
 
@@ -234,121 +233,182 @@ void attach_callbacks(void) {
 }
 
 void go_on_air() {
-  stage = 0;
-  status[13] = 1;
-  status[14] = 1;  // trigger lights
+    stage = 0;
+    status[13] = 1;
+    status[14] = 1;  // trigger lights
 }
 
 void go_off_air() {
-  stage = 0;
-  status[13] = 0;
-  status[14] = 1;  // trigger lights
+    stage = 0;
+    status[13] = 0;
+    status[14] = 1;  // trigger lights
 }
 
 /*
- * Button management.  All the reading, debouncings, latchings happens here.
- * the debounce is handled in two stages, a simulated RC filter and a schmitt trigger.
- */
+    Button management.  All the reading, debouncings, latchings happens here.
+    the debounce is handled in two stages, a simulated RC filter and a schmitt trigger.
+*/
 void read_btns(void) {
-    long temp=0;
+    long temp = 0;
     int state_change = 0;
 
-    for(pin=0; pin<NUM_INPUT; pin++){
+    for (pin = 0; pin < NUM_INPUT; pin++) {
         y_old[pin] = y_old[pin] - (y_old[pin] >> 2);
-        
-        if(digitalRead(input_pins[pin])==1){
-          y_old[pin] = y_old[pin] + 0x3F;
-        }
-                
-        if((y_old[pin] > 0xF0)&&(flag[pin]==1)) {
-            flag[pin]=0;
-            pin_state[pin]=1;
-            state_change=1;
+
+        if (digitalRead(input_pins[pin]) == 1) {
+            y_old[pin] = y_old[pin] + 0x3F;
         }
 
-        if((y_old[pin] < 0x0F)&&(flag[pin]==0)) {
-            flag[pin]=1;
-            pin_state[pin]=0;
-            state_change=1;
+        if ((y_old[pin] > 0xF0) && (flag[pin] == 1)) {
+            flag[pin] = 0;
+            pin_state[pin] = 1;
+            state_change = 1;
+        }
+
+        if ((y_old[pin] < 0x0F) && (flag[pin] == 0)) {
+            flag[pin] = 1;
+            pin_state[pin] = 0;
+            state_change = 1;
         }
         // handle this better for active high/low switches.
-        if((state_change==1)&&(pin_latched[pin]==0)&&pin_state[pin]==1) {
-            pin_latch_value[pin]=1;
-            pin_latched[pin]=1;
+        if ((state_change == 1) && (pin_latched[pin] == 0) && pin_state[pin] == 1) {
+            pin_latch_value[pin] = 1;
+            pin_latched[pin] = 1;
         }
-        state_change=0;
+        state_change = 0;
     }
 }
 
-/* 
- * Adjust servo height.  Input us an analog signal between ground and VCC+, constrained
- * by the values which make the camera visible.  Easiest adjustor is a slider/knob/rocker potentiometer, 
- * hower may move to buttons (momentary: short adjustment, long press: continuous adjustment.
- */
+
+/*
+    Setup low-level registers for controlling webcam servo using PWM.
+
+    The servo expects a pulse every ~20ms with a width between 1 and 2 ms.
+
+    A pulse of width 1ms will adjust the servo to one extreme; 2ms will move it to the other extreme.
+
+    Because FastLED interferes with the normal Servo library, we use the PWM hardware to control
+    the servo.
+
+    Since there is no high-level library that I'm aware of for doing this, we use the low-level
+    register-based interface for controlling this.
+
+    The webcam servo is on pin 2, which is controlled by timer 3.
+
+    Note: analogWrite will not work correctly on pins 2, 3, and 5 after we configure this!
+
+    See README.md for more info.
+*/
+void setup_webcam_servo_registers() {
+    // Set pin 2 to output.
+    pinMode(2, OUTPUT);
+    // TODO figure out how to get rid of this analogWrite function.
+    analogWrite(2, 127);
+    // I don't know what the top two bits in TCCR3B do, so not touching them.
+    // Set prescaler to 010, meaning clk / 8, meaning 2 MHz.
+    TCCR3B &= ~0x7;
+    TCCR3B |= 0x2;
+    // Set WGM33:WGM30 to 0b1110, which means fast PWM, with the timer wrapping around when
+    // its value equals ICR3.
+    // Set WGM33 and WGM32 to 0b11
+    TCCR3B |= (1 << WGM33) | (1 << WGM32);
+    // Set WGM31 and WGM30 to 0b10
+    TCCR3A |= (1 << WGM31);
+    TCCR3A &= ~(1 << WGM30);
+    // Set wrap-around point at 40,000. At 2 MHz this means we wrap around every 20ms.
+    ICR3 = 40000;
+}
+
+/*
+    Adjust servo height using PWM.
+
+    A value of 2000 written to OCR3B will result in a 2000 / 40000 * 20ms = 1ms pulse.
+
+    A value of 4000 will result in a 4000 / 40000 * 20ms = 2ms pulse.
+*/
+void set_webcam_servo_angle_pwm(int angle) {
+    // angle should be between 0 and 180
+    int pulse_width = map(angle, 0, 180, 2000, 4000);
+    Serial.println(pulse_width);
+    OCR3B = pulse_width;
+}
+
+int get_webcam_servo_angle_pwm() {
+    return map(OCR3B, 2000, 4000, 0, 180);
+}
+
+/*
+    Stop sending pulses to webcam servo.
+
+    If we don't detach after adjusting the position, the servo will burn out eventually.
+*/
+void detach_webcam_servo() {
+    // OCR3B = 0;
+}
+
+/*
+    Adjust servo height.  Input us an analog signal between ground and VCC+, constrained
+    by the values which make the camera visible.  Easiest adjustor is a slider/knob/rocker potentiometer,
+    hower may move to buttons (momentary: short adjustment, long press: continuous adjustment.
+*/
 void adjust_webcam_angle() {
-    int knob;
-    int current_angle = webcam_angle.read();
     static int running = 0;
-    
-    knob = analogRead(analog_pins[read_webcam_angle]);
+    int current_angle = get_webcam_servo_angle_pwm();
+    int knob = analogRead(analog_pins[read_webcam_angle]);
     knob = map(knob, 0, 1024, SERVO_MIN_ANGLE, SERVO_MAX_ANGLE);
-    if(abs(knob - current_angle) > 2) {
-      webcam_angle.attach(output_pins[set_webcam_angle]);
-      webcam_angle.write(knob);
-      timers[servo_delay]=millis();
-      running = 1;
+
+    if (abs(knob - current_angle) > 2) {
+        set_webcam_servo_angle_pwm(knob);
+        timers[servo_delay] = millis();
+        running = 1;
     }
-    
+
     if (running == 1 && (millis() - timers[servo_delay] > 50)) {
-      webcam_angle.detach();
-      running = 0;
+        detach_webcam_servo();
+        running = 0;
     }
 }
 
-/* 
- * Input handling.  Anything the arduino received gets processed here.
- */
+/*
+    Input handling.  Anything the arduino received gets processed here.
+*/
 void handle_input() {
 
     int idx = 0;
 
-    for(pin=0; pin<NUM_INPUT; pin++) {
-//        status[pin]=pin_state[pin];
-        status[pin]=digitalRead(input_pins[pin]);
+    for (pin = 0; pin < NUM_INPUT; pin++) {
+        //        status[pin]=pin_state[pin];
+        status[pin] = digitalRead(input_pins[pin]);
     }
     idx += NUM_INPUT;
 
-    for(pin=0; pin<NUM_OUTPUT; pin++) {
-        status[idx + pin]=digitalRead(output_pins[pin]);
+    for (pin = 0; pin < NUM_OUTPUT; pin++) {
+        status[idx + pin] = digitalRead(output_pins[pin]);
     }
     idx += NUM_OUTPUT;
 
-    for(pin=0; pin<NUM_INPUT; pin++) {
-        status[idx + pin]=pin_latched[pin];
+    for (pin = 0; pin < NUM_INPUT; pin++) {
+        status[idx + pin] = pin_latched[pin];
     }
-    
-    idx += NUM_INPUT;    
 
-    for(pin=0; pin<NUM_INPUT; pin++) {
-        status[idx + pin]=pin_latch_value[pin];
+    idx += NUM_INPUT;
+
+    for (pin = 0; pin < NUM_INPUT; pin++) {
+        status[idx + pin] = pin_latch_value[pin];
     }
 }
 
 /*
- * Process wait based execution here
- */
+    Process wait based execution here
+*/
 void keep_time() {
+    adjust_webcam_angle();
 
-    if (millis() - timers[servo_delay] > waits[servo_delay]) {
-      // timer reset in adjust_webcam_angle IF servo is moved
-        adjust_webcam_angle();
+    if (analogRead(analog_pins[read_pir]) > 500) {
+        status[12] = 1; // indicate a player is at the machine
+        timers[player_activity] = millis();
     }
-    
-    if(analogRead(analog_pins[read_pir]) > 500) {
-      status[12] = 1; // indicate a player is at the machine
-      timers[player_activity] = millis();
-    }
-    
+
     if ((millis() - timers[player_activity]) > waits[player_activity]) {
         status[12] = 0;  // timeout indication ot stream PC
         // need to send to rpi also, tbd till interface defined
@@ -362,39 +422,35 @@ void setup() {
     FastLED.addLeds<WS2812, CONT_BOX_PINA>(controller_boxA, CONT_BOX_A_NUM); // GRB
     FastLED.addLeds<WS2812, CONT_BOX_PINB>(controller_boxB, CONT_BOX_B_NUM); // GRB
     FastLED.addLeds<WS2812, CASE_PIN>(case_leds, CASE_NUM); // GRB
-    
+
     attach_callbacks();
     stage = 0;
-    
-    for(pin=0; pin<NUM_INPUT; pin++) {
+
+    for (pin = 0; pin < NUM_INPUT; pin++) {
         pin_latch_value[pin] = 0;   // Latched value set to 0, if not latched, this doesn't matter and is just an init
         pin_latched[pin] = 0;       // initially, no pins are latched.
         pin_active[pin] = 1;        // This is hard coded where it may be needed per pin in the future.
         pin_state[pin] = 0;         // This is just an initial value, doesn't matter.
-        y_old[pin]=0;
-        flag[pin]=0;
+        y_old[pin] = 0;
+        flag[pin] = 0;
     }
 
-    for(pin=0; pin<NUM_INPUT; pin++) {
+    for (pin = 0; pin < NUM_INPUT; pin++) {
         pinMode(input_pins[pin], INPUT_PULLUP);
     }
 
-    for(pin=0; pin<NUM_ANALOG; pin++) {
-        pinMode(analog_pins[pin], INPUT_PULLUP);
-    }
-
-    for(pin=0; pin<NUM_OUTPUT; pin++) {
+    for (pin = 0; pin < NUM_OUTPUT; pin++) {
         pinMode(output_pins[pin], OUTPUT);
         digitalWrite(output_pins[pin], HIGH);
     }
 
-    webcam_angle.attach(output_pins[set_webcam_angle]);
     timers[servo_delay] = millis();
     timers[player_activity] = millis();
+
+    setup_webcam_servo_registers();
 }
 
 void loop() {
-
     c.feedinSerialData();
     read_btns();
     handle_input();

--- a/arduino/arduino_controller/arduino_controller.ino
+++ b/arduino/arduino_controller/arduino_controller.ino
@@ -338,6 +338,15 @@ int get_webcam_servo_angle_pwm() {
 }
 
 /*
+    Detach from webcam servo.
+*/
+void detach_webcam_servo() {
+    // TODO: should we do something here? It seems to work fine if we just no-op here.
+    // Matt mentioned that he thought detaching is necessary to avoid burning out the servo,
+    // but he's not sure that's true.
+}
+
+/*
     Adjust servo height.  Input us an analog signal between ground and VCC+, constrained
     by the values which make the camera visible.  Easiest adjustor is a slider/knob/rocker potentiometer,
     hower may move to buttons (momentary: short adjustment, long press: continuous adjustment.

--- a/arduino/arduino_controller/arduino_controller.ino
+++ b/arduino/arduino_controller/arduino_controller.ino
@@ -338,15 +338,6 @@ int get_webcam_servo_angle_pwm() {
 }
 
 /*
-    Stop sending pulses to webcam servo.
-
-    If we don't detach after adjusting the position, the servo will burn out eventually.
-*/
-void detach_webcam_servo() {
-    // OCR3B = 0;
-}
-
-/*
     Adjust servo height.  Input us an analog signal between ground and VCC+, constrained
     by the values which make the camera visible.  Easiest adjustor is a slider/knob/rocker potentiometer,
     hower may move to buttons (momentary: short adjustment, long press: continuous adjustment.


### PR DESCRIPTION
Define a function `set_webcam_servo_angle_pwm` that sets the webcam servo's angle using the PWM feature on one of the pins. Since it uses PWM, it's independent of interrupts and therefore works properly with FastLED.

Note: I also reformatted the file using Arduino's code formatting feature, hence the larger diff.